### PR TITLE
stdin is only received from pipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +107,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chiritori"
 version = "0.1.0"
 dependencies = [
+ "atty",
  "chrono",
  "clap",
 ]
@@ -171,6 +183,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -331,6 +352,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.34"
 clap = { version = "4.5.1", features = ["derive"] }
+atty = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,14 @@ fn main() {
     let mut content = String::new();
 
     if args.filename.is_none() {
-        std::io::stdin()
-            .read_to_string(&mut content)
-            .expect("something went wrong reading the file");
+        if atty::isnt(atty::Stream::Stdin) {
+            std::io::stdin()
+                .read_to_string(&mut content)
+                .expect("something went wrong reading the file");
+        } else {
+            println!("No input file or stdin. More information: --help");
+            std::process::exit(1);
+        }
     } else {
         let mut f = File::open(args.filename.unwrap()).expect("file not found");
         f.read_to_string(&mut content)


### PR DESCRIPTION
`--filename` オプションでのファイル指定やパイプによる入力がないとき、標準入力の待ちが発生するのですが、この場合は即時終了としたいのでした。