### PR TITLE
Add formatter to remove next line break

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,4 +1,5 @@
 pub mod indent_remover;
+pub mod next_line_break_remover;
 pub mod prev_line_break_remover;
 
 pub trait Formatter {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,6 +1,8 @@
+pub mod empty_line_remover;
 pub mod indent_remover;
 pub mod next_line_break_remover;
 pub mod prev_line_break_remover;
+pub mod utils;
 
 pub trait Formatter {
     fn format(&self, content: &mut String, byte_pos: usize) -> usize;
@@ -45,22 +47,120 @@ mod tests {
 
     #[test]
     fn test_format() {
+        let strategy: Vec<Box<dyn Formatter>> = vec![
+            Box::new(indent_remover::IndentRemover {}),
+            Box::new(empty_line_remover::EmptyLineRemover {}),
+            Box::new(prev_line_break_remover::PrevLineBreakRemover {}),
+            Box::new(next_line_break_remover::NextLineBreakRemover {}),
+        ];
+
+        // source:        converted:
+        //  1 |<div>         1 |<div>
+        //  2 |....hoge      2 |....hoge
+        //  3 |....X         3 |....foo
+        //  4 |....foo       4 |....bar
+        //  5 |....bar       5 |....baz
+        //  6 |....baz       6 |
+        //  7 |              7 |</div>
+        //  8 |....X         8 |
+        //  9 |</div>
+        //
         //                       10        20       30        40        50
         //             01234567890123456789012345678901234567890123456789012345
-        //                                 ^                            ^
-        let content = "+<div>+    hoge+    +    foo+    bar+    baz+    +</div>".replace('+', "\n");
-        let removed_pos = &vec![20, 49];
+        //                                ^                             ^
+        let content = "<div>+    hoge+    +    foo+    bar+    baz++    +</div>".replace('+', "\n");
+        let removed_pos = &vec![19, 49];
         assert_eq!(
             format(
                 &content,
                 &removed_pos,
-                &vec![
-                    Box::new(indent_remover::IndentRemover {}),
-                    Box::new(prev_line_break_remover::PrevLineBreakRemover {}),
-                ]
+                &strategy
             ),
-            //123456789012345678901234567890123456789012345
-            "+<div>+    hoge+    foo+    bar+    baz+</div>".replace('+', "\n")
+            //12345678901234567890123456789012345678901234567
+            "<div>+    hoge+    foo+    bar+    baz++</div>".replace('+', "\n")
+        );
+
+        // source:        converted:
+        //  1 |....hoge      1 |....hoge
+        //  2 |....X         2 |....foo
+        //  3 |....foo
+        //
+        //                       10        20
+        //             0123456789012345678901
+        //                          ^
+        let content = "    hoge+    +    foo+".replace('+', "\n");
+        let removed_pos = &vec![13];
+        assert_eq!(
+            format(
+                &content,
+                &removed_pos,
+                &strategy
+            ),
+            //12345678901234567890123456789012345678901234567
+            "    hoge+    foo+".replace('+', "\n")
+        );
+
+        // source:        converted:
+        //  1 |....hoge      1 |....hoge
+        //  2 |              2 |
+        //  3 |....X         3 |....foo
+        //  4 |....foo
+        //
+        //                       10        20
+        //             01234567890123456789012
+        //                           ^
+        let content = "    hoge++    +    foo+".replace('+', "\n");
+        let removed_pos = &vec![14];
+        assert_eq!(
+            format(
+                &content,
+                &removed_pos,
+                &strategy
+            ),
+            //12345678901234567890123456789012345678901234567
+            "    hoge++    foo+".replace('+', "\n")
+        );
+
+        // source:        converted:
+        //  1 |....hoge      1 |....hoge
+        //  2 |....X         2 |
+        //  3 |              3 |....foo
+        //  4 |....foo
+        //
+        //                       10        20
+        //             01234567890123456789012
+        //                           ^
+        let content = "    hoge+    ++    foo+".replace('+', "\n");
+        let removed_pos = &vec![14];
+        assert_eq!(
+            format(
+                &content,
+                &removed_pos,
+                &strategy
+            ),
+            //12345678901234567890123456789012345678901234567
+            "    hoge++    foo+".replace('+', "\n")
+        );
+
+        // source:        converted:
+        //  1 |....hoge      1 |....hoge
+        //  2 |.             2 |
+        //  3 |....X         3 |....foo
+        //  4 |.
+        //  5 |....foo
+        //                       10        20
+        //             01234567890123456789012
+        //                            ^
+        let content = "    hoge+ +    + +    foo+".replace('+', "\n");
+        let removed_pos = &vec![15];
+        assert_eq!(
+            format(
+                &content,
+                &removed_pos,
+                &strategy
+            ),
+            //12345678901234567890123456789012345678901234567
+            "    hoge++    foo+".replace('+', "\n")
         );
 
         // RemovePos 26 is unprossed because RemovePos 31 is formatted including RemovePos 26.
@@ -77,7 +177,7 @@ mod tests {
                 &vec![Box::new(prev_line_break_remover::PrevLineBreakRemover {}),]
             ),
             //123456789012345678901234567890123456789012345
-            "+<div>+    +    +    +    +</div>".replace('+', "\n")
+            "+<div>+    +    +    ++</div>".replace('+', "\n")
         );
 
         //                       10        20

--- a/src/formatter/empty_line_remover.rs
+++ b/src/formatter/empty_line_remover.rs
@@ -1,0 +1,72 @@
+use super::utils::line_break_pos_finder::find_next_line_break_pos;
+use super::utils::line_break_pos_finder::find_prev_line_break_pos;
+use super::Formatter;
+
+pub struct EmptyLineRemover {}
+
+impl Formatter for EmptyLineRemover {
+    fn format(&self, content: &mut String, byte_pos: usize) -> usize {
+        let bytes = content.as_bytes();
+
+        if !content.is_char_boundary(byte_pos) {
+            panic!("Invalid byte position: {}", byte_pos);
+        }
+
+        if bytes.get(byte_pos) != Some(&b'\n') {
+            return byte_pos;
+        }
+
+        let is_next_line_empty = find_next_line_break_pos(content, bytes, byte_pos)
+            .map(|pos| find_next_line_break_pos(content, bytes, pos + 1))
+            .flatten()
+            == None;
+        let is_prev_line_empty = find_prev_line_break_pos(content, bytes, byte_pos)
+            .map(|pos| find_prev_line_break_pos(content, bytes, pos))
+            .flatten()
+            == None;
+
+        if is_next_line_empty && is_prev_line_empty {
+            content.replace_range(byte_pos..(byte_pos + 1), "");
+        }
+
+        byte_pos
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format() {
+        let remover = EmptyLineRemover {};
+
+        //                          10        20
+        //                 0123456789012345
+        //                 |        ^
+        let mut content = "    hoge++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 9), 9);
+        assert_eq!(content, "    hoge+  foo".replace('+', "\n"));
+
+        //                          10        20
+        //                 0123456789012345
+        //                 |         ^
+        let mut content = "    hoge+++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 10), 10);
+        assert_eq!(content, "    hoge+++  foo".replace('+', "\n"));
+
+        //                          10        20
+        //                 0123456789012345
+        //                 |        ^
+        let mut content = "    hoge+++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 9), 9);
+        assert_eq!(content, "    hoge+++  foo".replace('+', "\n"));
+
+        //                          10        20
+        //                 0123456789012345
+        //                 |         ^
+        let mut content = "    hoge++ +  foo".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 10), 10);
+        assert_eq!(content, "    hoge++ +  foo".replace('+', "\n"));
+    }
+}

--- a/src/formatter/next_line_break_remover.rs
+++ b/src/formatter/next_line_break_remover.rs
@@ -1,11 +1,13 @@
+use super::utils::line_break_pos_finder::find_next_line_break_pos;
 use super::Formatter;
-
 pub struct NextLineBreakRemover {}
 
 impl Formatter for NextLineBreakRemover {
     fn format(&self, content: &mut String, byte_pos: usize) -> usize {
-        let line_break_pos = find_line_break_pos(content, byte_pos)
-            .map(|pos| find_line_break_pos(content, pos + 1))
+        let bytes = content.as_bytes();
+
+        let line_break_pos = find_next_line_break_pos(content, bytes, byte_pos)
+            .map(|pos| find_next_line_break_pos(content, bytes, pos + 1))
             .flatten();
 
         if let Some(line_break_pos) = line_break_pos {
@@ -13,28 +15,6 @@ impl Formatter for NextLineBreakRemover {
         }
 
         byte_pos
-    }
-}
-
-fn find_line_break_pos(content: &str, byte_pos: usize) -> Option<usize> {
-    let mut cursor = byte_pos;
-    let bytes = content.as_bytes();
-
-    loop {
-        if cursor >= bytes.len() || cursor == 0 {
-            break None;
-        }
-
-        if content.is_char_boundary(cursor) {
-            match bytes.get(cursor) {
-                Some(b' ') => {}
-                Some(b'\n') => break Some(cursor),
-                None => break None,
-                _ => break None,
-            };
-        }
-
-        cursor = cursor + 1;
     }
 }
 

--- a/src/formatter/next_line_break_remover.rs
+++ b/src/formatter/next_line_break_remover.rs
@@ -1,0 +1,104 @@
+use super::Formatter;
+
+pub struct NextLineBreakRemover {}
+
+impl Formatter for NextLineBreakRemover {
+    fn format(&self, content: &mut String, byte_pos: usize) -> usize {
+        let line_break_pos = find_line_break_pos(content, byte_pos)
+            .map(|pos| find_line_break_pos(content, pos + 1))
+            .flatten();
+
+        if let Some(line_break_pos) = line_break_pos {
+            content.replace_range(byte_pos..line_break_pos, "");
+        }
+
+        byte_pos
+    }
+}
+
+fn find_line_break_pos(content: &str, byte_pos: usize) -> Option<usize> {
+    let mut cursor = byte_pos;
+    let bytes = content.as_bytes();
+
+    loop {
+        if cursor >= bytes.len() || cursor == 0 {
+            break None;
+        }
+
+        if content.is_char_boundary(cursor) {
+            match bytes.get(cursor) {
+                Some(b' ') => {}
+                Some(b'\n') => break Some(cursor),
+                None => break None,
+                _ => break None,
+            };
+        }
+
+        cursor = cursor + 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format() {
+        let remover = NextLineBreakRemover {};
+
+        //                          10        20
+        //                 012345678901234567890123456
+        //                 |            ^  ^
+        let mut content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 13), 13);
+        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+
+        //                          10        20
+        //                 012345678901234567890123456
+        //                 |            ^
+        let mut content = "    hoge+      +    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 13), 13);
+        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+
+        //                          10        20
+        //                 012345678901234567890123456
+        //                 |            ^
+        let mut content = "    hoge+    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 13), 13);
+        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+
+        //                          10
+        //                 01234567890123456
+        //                 |            ^
+        let mut content = "    hoge+    +  ".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 13), 13);
+        assert_eq!(content, "    hoge+    +  ".replace('+', "\n"));
+
+        //                          10        20
+        //                 012345678901234567890123456
+        //                 |            ^
+        let mut content = "    hoge+    ++++    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 13), 13);
+        assert_eq!(content, "    hoge+    +++    foo</div>".replace('+', "\n"));
+
+        //                          10
+        //                 01234567890123
+        //                 |  ^
+        let mut content = "aaaabaz</div>".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 3), 3);
+        assert_eq!(content, "aaaabaz</div>".replace('+', "\n"));
+
+        //                          10
+        //                 012345.890123
+        //                 |     ^
+        let mut content = "aaa+ あ</div>".replace('+', "\n");
+        assert_eq!(remover.format(&mut content, 7), 7);
+        assert_eq!(content, "aaa+ あ</div>".replace('+', "\n"));
+
+        let mut content = "".to_string();
+        assert_eq!(remover.format(&mut content, 0), 0);
+
+        let mut content = "\n".to_string();
+        assert_eq!(remover.format(&mut content, 0), 0);
+    }
+}

--- a/src/formatter/utils.rs
+++ b/src/formatter/utils.rs
@@ -1,0 +1,1 @@
+pub mod line_break_pos_finder;

--- a/src/formatter/utils/line_break_pos_finder.rs
+++ b/src/formatter/utils/line_break_pos_finder.rs
@@ -1,0 +1,149 @@
+pub fn find_next_line_break_pos(content: &str, bytes: &[u8], byte_pos: usize) -> Option<usize> {
+    let mut cursor = byte_pos;
+
+    loop {
+        if cursor >= bytes.len() || cursor == 0 {
+            break None;
+        }
+
+        match check(content, bytes, &cursor) {
+            CheckResult::Skip => {}
+            CheckResult::Found => break Some(cursor),
+            CheckResult::None => break None,
+        }
+
+        cursor = cursor + 1;
+    }
+}
+
+pub fn find_prev_line_break_pos(content: &str, bytes: &[u8], byte_pos: usize) -> Option<usize> {
+    let mut cursor = byte_pos;
+
+    if cursor == 0 {
+        return None;
+    }
+
+    loop {
+        cursor = cursor - 1;
+
+        if cursor >= bytes.len() || cursor == 0 {
+            break None;
+        }
+
+        match check(content, bytes, &cursor) {
+            CheckResult::Skip => {}
+            CheckResult::Found => break Some(cursor),
+            CheckResult::None => break None,
+        }
+    }
+}
+
+enum CheckResult {
+    Skip,
+    Found,
+    None,
+}
+
+fn check(content: &str, bytes: &[u8], cursor: &usize) -> CheckResult {
+    if !content.is_char_boundary(*cursor) {
+        return CheckResult::Skip;
+    }
+
+    match bytes.get(*cursor) {
+        Some(b' ') => CheckResult::Skip,
+        Some(b'\n') => CheckResult::Found,
+        None => CheckResult::None,
+        _ => CheckResult::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_next_line_break_pos() {
+        //             012345678901234567890123456789
+        //                          ^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_next_line_break_pos(&content, content.as_bytes(), 13),
+            Some(13)
+        );
+
+        //             012345678901234567890123456789
+        //                         ^^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_next_line_break_pos(&content, content.as_bytes(), 12),
+            Some(13)
+        );
+
+        //             012345678901234567890123456789
+        //                            ^^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_next_line_break_pos(&content, content.as_bytes(), 15),
+            Some(16)
+        );
+
+        //             01234567890123.6789012345678901
+        //                              ^
+        let content = "    hoge+    あ  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_next_line_break_pos(&content, content.as_bytes(), 14),
+            Some(18)
+        );
+
+        //             012345678901234567890123456789
+        //                                    ^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_next_line_break_pos(&content, content.as_bytes(), 23),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_prev_line_break_pos() {
+        //             012345678901234567890123456789
+        //                     ^    ^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_prev_line_break_pos(&content, content.as_bytes(), 13),
+            Some(8)
+        );
+
+        //             012345678901234567890123456789
+        //                          ^^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_prev_line_break_pos(&content, content.as_bytes(), 14),
+            Some(13)
+        );
+
+        //             012345678901234567890123456789
+        //                             ^ ^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_prev_line_break_pos(&content, content.as_bytes(), 18),
+            Some(16)
+        );
+
+        //             0123456789012345678.0123456789
+        //                             ^
+        let content = "    hoge+    +  + あ   foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_prev_line_break_pos(&content, content.as_bytes(), 19),
+            None
+        );
+
+        //             012345678901234567890123456789
+        //                                    ^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(
+            find_prev_line_break_pos(&content, content.as_bytes(), 23),
+            None
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,7 @@ fn main() {
     let formatter: Vec<Box<dyn Formatter>> = vec![
         Box::new(formatter::indent_remover::IndentRemover {}),
         Box::new(formatter::prev_line_break_remover::PrevLineBreakRemover {}),
+        Box::new(formatter::next_line_break_remover::NextLineBreakRemover {}),
     ];
     let cleaned = formatter::format(&removed, &removed_pos, &formatter);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ fn main() {
     let removed_pos = remover::get_removed_pos(&markers);
     let formatter: Vec<Box<dyn Formatter>> = vec![
         Box::new(formatter::indent_remover::IndentRemover {}),
+        Box::new(formatter::empty_line_remover::EmptyLineRemover {}),
         Box::new(formatter::prev_line_break_remover::PrevLineBreakRemover {}),
         Box::new(formatter::next_line_break_remover::NextLineBreakRemover {}),
     ];


### PR DESCRIPTION
削除した部分の前方のはじめの改行を削除するFormatterを追加します。この変更にあわせて、既存のFormatterの修正も行います。

## NextLineBreakRemoverの追加

現状のchiritoriに、以下のファイルに対してchiritoriで変換をかけると

```
1 | Foo
2 |  <!-- time-limited to="2000-01-01 00:00:00" -->
3 |    Campaign until 1999-12-31 23:59
4 |  <!-- /time-limited -->
5 |
6 |  Bar
```

以下のような結果が得られます。

```
1 |  Foo
2 |
3 |
4 |  Bar
```

これを以下のようにフォーマットするものです。削除位置から見て空行が2連続する場合は、直後の空行を削除します。

```
1 |  Foo
2 |
3 |  Bar
```

## PrevLineBreakRemoverの修正

この変更とあわせて、これまでのPrevLineBreakRemoverのルールも「削除位置から見て空行が2連続する場合は、直前の空行を削除」するようにルールを修正します。

### 入力値

```
1 | foo
2 |
3 |  <!-- time-limited to="2000-01-01 00:00:00" -->
4 |    Campaign until 1999-12-31 23:59
5 |  <!-- /time-limited -->
6 |  bar
```

### 出力値

```
1 |  foo
2 |
3 |  bar
```

## EmptyLineRemoverの追加

ただし、以下のように削除位置周辺に空行がない場合は、これまで通り空行が削除されるようにEmptyLineRemoverを追加します。削除位置の直後が改行で、かつ前後に空行がない場合には削除位置の直後の改行を削除します。

### 入力値

```
1 | foo
2 |  <!-- time-limited to="2000-01-01 00:00:00" -->
3 |    Campaign until 1999-12-31 23:59
4 |  <!-- /time-limited -->
5 |  bar
```

### 出力値

```
1 |  foo
2 |  bar
```

