### PR TITLE
Fix the formatter to avoid conflicts in the processing of remove markers

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -5,7 +5,7 @@ pub mod prev_line_break_remover;
 pub mod utils;
 
 pub trait Formatter {
-    fn format(&self, content: &mut String, byte_pos: usize) -> usize;
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize);
 }
 
 pub fn format(
@@ -25,17 +25,18 @@ pub fn format(
                     }
                 }
 
-                let mut pos = *pos;
-
-                if !acc.is_char_boundary(pos) {
-                    panic!("Invalid byte position: {}", pos);
+                if !acc.is_char_boundary(*pos) {
+                    panic!("Invalid byte position: {}", *pos);
                 }
 
-                formatters.iter().for_each(|f| {
-                    pos = f.format(&mut acc, pos);
+                let updated_pos = formatters.iter().fold(*pos, |pos, f| {
+                    let (start, end) = f.format(&mut acc, pos);
+                    acc.replace_range(start..end, "");
+
+                    start
                 });
 
-                (acc, Some(pos))
+                (acc, Some(updated_pos))
             },
         )
         .0

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -5,7 +5,7 @@ pub mod prev_line_break_remover;
 pub mod utils;
 
 pub trait Formatter {
-    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize);
+    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize);
 }
 
 pub fn format(
@@ -13,33 +13,26 @@ pub fn format(
     removed_pos: &Vec<usize>,
     formatters: &Vec<Box<dyn self::Formatter>>,
 ) -> String {
-    removed_pos
-        .iter()
-        .rev()
-        .fold(
-            (content.to_string(), None),
-            |(mut acc, processed_pos), pos| {
-                if let Some(processed_pos) = processed_pos {
-                    if *pos >= processed_pos {
-                        return (acc, Some(processed_pos));
-                    }
-                }
+    let mut iter = removed_pos.iter().rev().peekable();
 
-                if !acc.is_char_boundary(*pos) {
-                    panic!("Invalid byte position: {}", *pos);
-                }
+    let mut content = content.to_string();
+    while let Some(pos) = iter.next() {
+        let next_pos = iter.peek().map_or(0, |p| **p);
 
-                let updated_pos = formatters.iter().fold(*pos, |pos, f| {
-                    let (start, end) = f.format(&mut acc, pos);
-                    acc.replace_range(start..end, "");
+        if !content.is_char_boundary(*pos) {
+            panic!("Invalid byte position: {}", pos);
+        }
 
-                    start
-                });
+        formatters.iter().fold(*pos, |pos, f| {
+            let (start, end) = f.format(&mut content, pos, next_pos);
+            let start = std::cmp::max(start, next_pos);
+            content.replace_range(start..end, "");
 
-                (acc, Some(updated_pos))
-            },
-        )
-        .0
+            start
+        });
+    }
+
+    content
 }
 
 #[cfg(test)]
@@ -72,11 +65,7 @@ mod tests {
         let content = "<div>+    hoge+    +    foo+    bar+    baz++    +</div>".replace('+', "\n");
         let removed_pos = &vec![19, 49];
         assert_eq!(
-            format(
-                &content,
-                &removed_pos,
-                &strategy
-            ),
+            format(&content, &removed_pos, &strategy),
             //12345678901234567890123456789012345678901234567
             "<div>+    hoge+    foo+    bar+    baz++</div>".replace('+', "\n")
         );
@@ -92,11 +81,7 @@ mod tests {
         let content = "    hoge+    +    foo+".replace('+', "\n");
         let removed_pos = &vec![13];
         assert_eq!(
-            format(
-                &content,
-                &removed_pos,
-                &strategy
-            ),
+            format(&content, &removed_pos, &strategy),
             //12345678901234567890123456789012345678901234567
             "    hoge+    foo+".replace('+', "\n")
         );
@@ -113,11 +98,7 @@ mod tests {
         let content = "    hoge++    +    foo+".replace('+', "\n");
         let removed_pos = &vec![14];
         assert_eq!(
-            format(
-                &content,
-                &removed_pos,
-                &strategy
-            ),
+            format(&content, &removed_pos, &strategy),
             //12345678901234567890123456789012345678901234567
             "    hoge++    foo+".replace('+', "\n")
         );
@@ -134,11 +115,7 @@ mod tests {
         let content = "    hoge+    ++    foo+".replace('+', "\n");
         let removed_pos = &vec![14];
         assert_eq!(
-            format(
-                &content,
-                &removed_pos,
-                &strategy
-            ),
+            format(&content, &removed_pos, &strategy),
             //12345678901234567890123456789012345678901234567
             "    hoge++    foo+".replace('+', "\n")
         );
@@ -155,17 +132,13 @@ mod tests {
         let content = "    hoge+ +    + +    foo+".replace('+', "\n");
         let removed_pos = &vec![15];
         assert_eq!(
-            format(
-                &content,
-                &removed_pos,
-                &strategy
-            ),
+            format(&content, &removed_pos, &strategy),
             //12345678901234567890123456789012345678901234567
             "    hoge++    foo+".replace('+', "\n")
         );
 
-        // RemovePos 26 is unprossed because RemovePos 31 is formatted including RemovePos 26.
-        // (If RemovePos 26 is processed, RemovePos 26 is out of range after RemovePos 31 is formatted.)
+        // RemovePos 31 is unprossed because it conflicts with RemovePos 26
+        //
         //                       10        20       30        40
         //             0123456789012345678901234567890123456789012
         //                                       ^    ^
@@ -178,7 +151,7 @@ mod tests {
                 &vec![Box::new(prev_line_break_remover::PrevLineBreakRemover {}),]
             ),
             //123456789012345678901234567890123456789012345
-            "+<div>+    +    +    ++</div>".replace('+', "\n")
+            "+<div>+    +    ++    +</div>".replace('+', "\n")
         );
 
         //                       10        20

--- a/src/formatter/empty_line_remover.rs
+++ b/src/formatter/empty_line_remover.rs
@@ -5,7 +5,7 @@ use super::Formatter;
 pub struct EmptyLineRemover {}
 
 impl Formatter for EmptyLineRemover {
-    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         if !content.is_char_boundary(byte_pos) {
@@ -23,7 +23,7 @@ impl Formatter for EmptyLineRemover {
         let is_prev_line_empty = find_prev_line_break_pos(content, bytes, byte_pos)
             .map(|pos| find_prev_line_break_pos(content, bytes, pos))
             .flatten()
-            == None;
+            .map_or(true, |pos| pos <= next_byte_pos);
 
         if is_next_line_empty && is_prev_line_empty {
             (byte_pos, byte_pos + 1)
@@ -45,24 +45,31 @@ mod tests {
         //             0123456789012345
         //             |        ^
         let content = "    hoge++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 9), (9, 10));
+        assert_eq!(remover.format(&content, 9, 0), (9, 10));
+
+        //                      10
+        //             0123456789012345
+        //       (remove marker)^|
+        //             |         ^
+        let content = "    hoge+++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&content, 10, 9), (10, 11));
 
         //                      10
         //             0123456789012345
         //             |         ^
         let content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10), (10, 10));
+        assert_eq!(remover.format(&content, 10, 0), (10, 10));
 
         //                      10
         //             0123456789012345
         //             |        ^
         let content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 9), (9, 9));
+        assert_eq!(remover.format(&content, 9, 0), (9, 9));
 
         //                      10
         //             01234567890123456
         //             |         ^
         let content = "    hoge++ +  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10), (10, 10));
+        assert_eq!(remover.format(&content, 10, 0), (10, 10));
     }
 }

--- a/src/formatter/empty_line_remover.rs
+++ b/src/formatter/empty_line_remover.rs
@@ -5,7 +5,7 @@ use super::Formatter;
 pub struct EmptyLineRemover {}
 
 impl Formatter for EmptyLineRemover {
-    fn format(&self, content: &mut String, byte_pos: usize) -> usize {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         if !content.is_char_boundary(byte_pos) {
@@ -13,7 +13,7 @@ impl Formatter for EmptyLineRemover {
         }
 
         if bytes.get(byte_pos) != Some(&b'\n') {
-            return byte_pos;
+            return (byte_pos, byte_pos);
         }
 
         let is_next_line_empty = find_next_line_break_pos(content, bytes, byte_pos)
@@ -26,10 +26,10 @@ impl Formatter for EmptyLineRemover {
             == None;
 
         if is_next_line_empty && is_prev_line_empty {
-            content.replace_range(byte_pos..(byte_pos + 1), "");
+            (byte_pos, byte_pos + 1)
+        } else {
+            (byte_pos, byte_pos)
         }
-
-        byte_pos
     }
 }
 
@@ -41,32 +41,28 @@ mod tests {
     fn test_format() {
         let remover = EmptyLineRemover {};
 
-        //                          10        20
-        //                 0123456789012345
-        //                 |        ^
-        let mut content = "    hoge++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 9), 9);
-        assert_eq!(content, "    hoge+  foo".replace('+', "\n"));
+        //                      10
+        //             0123456789012345
+        //             |        ^
+        let content = "    hoge++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&content, 9), (9, 10));
 
-        //                          10        20
-        //                 0123456789012345
-        //                 |         ^
-        let mut content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 10), 10);
-        assert_eq!(content, "    hoge+++  foo".replace('+', "\n"));
+        //                      10
+        //             0123456789012345
+        //             |         ^
+        let content = "    hoge+++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&content, 10), (10, 10));
 
-        //                          10        20
-        //                 0123456789012345
-        //                 |        ^
-        let mut content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 9), 9);
-        assert_eq!(content, "    hoge+++  foo".replace('+', "\n"));
+        //                      10
+        //             0123456789012345
+        //             |        ^
+        let content = "    hoge+++  foo".replace('+', "\n");
+        assert_eq!(remover.format(&content, 9), (9, 9));
 
-        //                          10        20
-        //                 0123456789012345
-        //                 |         ^
-        let mut content = "    hoge++ +  foo".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 10), 10);
-        assert_eq!(content, "    hoge++ +  foo".replace('+', "\n"));
+        //                      10
+        //             01234567890123456
+        //             |         ^
+        let content = "    hoge++ +  foo".replace('+', "\n");
+        assert_eq!(remover.format(&content, 10), (10, 10));
     }
 }

--- a/src/formatter/indent_remover.rs
+++ b/src/formatter/indent_remover.rs
@@ -2,7 +2,7 @@ use super::Formatter;
 pub struct IndentRemover {}
 
 impl Formatter for IndentRemover {
-    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
         let mut cursor = byte_pos;
         let bytes = content.as_bytes();
 
@@ -16,6 +16,10 @@ impl Formatter for IndentRemover {
             }
 
             cursor = cursor - 1;
+
+            if cursor <= next_byte_pos {
+                break false;
+            }
 
             let current = bytes.get(cursor);
 
@@ -55,7 +59,13 @@ mod tests {
         //             0123456789012345678901234567890123
         //             |               ^   ^
         let content = "+<div>+    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 20), (16, 20));
+        assert_eq!(remover.format(&content, 20, 0), (16, 20));
+
+        //                      10        20        30
+        //             0123456789012345678901234567890123
+        //             |  (remove marker)^ ^
+        let content = "+<div>+    hoge+    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 20, 18), (20, 20));
 
         // if next char is '\n', and previous char is not space, do nothing
         //
@@ -63,7 +73,7 @@ mod tests {
         //             0123456789012345678901234567890123
         //             |            ^
         let content = "+<div>+hoge++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 13));
+        assert_eq!(remover.format(&content, 13, 0), (13, 13));
 
         // if next char is not '\n', do nothing
         //
@@ -71,7 +81,7 @@ mod tests {
         //             012345678901
         //             |      ^
         let content = "hoge+  a+baz".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7), (7, 7));
+        assert_eq!(remover.format(&content, 7, 0), (7, 7));
 
         // if next char is not '\n', do nothing
         //
@@ -79,7 +89,7 @@ mod tests {
         //             012345678901
         //             | ^
         let content = "  +baz".replace('+', "\n");
-        assert_eq!(remover.format(&content, 2), (2, 2));
+        assert_eq!(remover.format(&content, 2, 0), (2, 2));
 
         // if char boundary is invalid, do nothing
         //
@@ -87,12 +97,12 @@ mod tests {
         //             0123456789.2345678901234567890123
         //             |         ^
         let content = "+<div>+  あ  +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10), (10, 10));
+        assert_eq!(remover.format(&content, 10, 0), (10, 10));
 
         let content = "".to_string();
-        assert_eq!(remover.format(&content, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0, 0), (0, 0));
 
         let content = "\n".to_string();
-        assert_eq!(remover.format(&content, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0, 0), (0, 0));
     }
 }

--- a/src/formatter/next_line_break_remover.rs
+++ b/src/formatter/next_line_break_remover.rs
@@ -3,7 +3,7 @@ use super::Formatter;
 pub struct NextLineBreakRemover {}
 
 impl Formatter for NextLineBreakRemover {
-    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, _next_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_next_line_break_pos(content, bytes, byte_pos)
@@ -30,48 +30,48 @@ mod tests {
         //             012345678901234567890123456
         //             |            ^  ^
         let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 16));
+        assert_eq!(remover.format(&content, 13, 0), (13, 16));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+      +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 20));
+        assert_eq!(remover.format(&content, 13, 0), (13, 20));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 13));
+        assert_eq!(remover.format(&content, 13, 0), (13, 13));
 
         //                      10
         //             01234567890123456
         //             |            ^
         let content = "    hoge+    +  ".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 13));
+        assert_eq!(remover.format(&content, 13, 0), (13, 13));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+    ++++    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 14));
+        assert_eq!(remover.format(&content, 13, 0), (13, 14));
 
         //                      10
         //             01234567890123
         //             |  ^
         let content = "aaaabaz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 3), (3, 3));
+        assert_eq!(remover.format(&content, 3, 0), (3, 3));
 
         //                     10
         //             012345.890123
         //             |     ^
         let content = "aaa+ あ</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7), (7, 7));
+        assert_eq!(remover.format(&content, 7, 0), (7, 7));
 
         let content = "".to_string();
-        assert_eq!(remover.format(&content, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0, 0), (0, 0));
 
         let content = "\n".to_string();
-        assert_eq!(remover.format(&content, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0, 0), (0, 0));
     }
 }

--- a/src/formatter/next_line_break_remover.rs
+++ b/src/formatter/next_line_break_remover.rs
@@ -3,7 +3,7 @@ use super::Formatter;
 pub struct NextLineBreakRemover {}
 
 impl Formatter for NextLineBreakRemover {
-    fn format(&self, content: &mut String, byte_pos: usize) -> usize {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_next_line_break_pos(content, bytes, byte_pos)
@@ -11,10 +11,10 @@ impl Formatter for NextLineBreakRemover {
             .flatten();
 
         if let Some(line_break_pos) = line_break_pos {
-            content.replace_range(byte_pos..line_break_pos, "");
+            (byte_pos, line_break_pos)
+        } else {
+            (byte_pos, byte_pos)
         }
-
-        byte_pos
     }
 }
 
@@ -26,59 +26,52 @@ mod tests {
     fn test_format() {
         let remover = NextLineBreakRemover {};
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |            ^  ^
-        let mut content = "    hoge+    +  +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             012345678901234567890123456
+        //             |            ^  ^
+        let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 16));
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |            ^
-        let mut content = "    hoge+      +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             012345678901234567890123456
+        //             |            ^
+        let content = "    hoge+      +    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 20));
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |            ^
-        let mut content = "    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             012345678901234567890123456
+        //             |            ^
+        let content = "    hoge+    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
-        //                          10
-        //                 01234567890123456
-        //                 |            ^
-        let mut content = "    hoge+    +  ".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+    +  ".replace('+', "\n"));
+        //                      10
+        //             01234567890123456
+        //             |            ^
+        let content = "    hoge+    +  ".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |            ^
-        let mut content = "    hoge+    ++++    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+    +++    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             012345678901234567890123456
+        //             |            ^
+        let content = "    hoge+    ++++    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 14));
 
-        //                          10
-        //                 01234567890123
-        //                 |  ^
-        let mut content = "aaaabaz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 3), 3);
-        assert_eq!(content, "aaaabaz</div>".replace('+', "\n"));
+        //                      10
+        //             01234567890123
+        //             |  ^
+        let content = "aaaabaz</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 3), (3, 3));
 
-        //                          10
-        //                 012345.890123
-        //                 |     ^
-        let mut content = "aaa+ あ</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 7), 7);
-        assert_eq!(content, "aaa+ あ</div>".replace('+', "\n"));
+        //                     10
+        //             012345.890123
+        //             |     ^
+        let content = "aaa+ あ</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 7), (7, 7));
 
-        let mut content = "".to_string();
-        assert_eq!(remover.format(&mut content, 0), 0);
+        let content = "".to_string();
+        assert_eq!(remover.format(&content, 0), (0, 0));
 
-        let mut content = "\n".to_string();
-        assert_eq!(remover.format(&mut content, 0), 0);
+        let content = "\n".to_string();
+        assert_eq!(remover.format(&content, 0), (0, 0));
     }
 }

--- a/src/formatter/prev_line_break_remover.rs
+++ b/src/formatter/prev_line_break_remover.rs
@@ -4,7 +4,7 @@ use super::Formatter;
 pub struct PrevLineBreakRemover {}
 
 impl Formatter for PrevLineBreakRemover {
-    fn format(&self, content: &mut String, byte_pos: usize) -> usize {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_prev_line_break_pos(content, bytes, byte_pos)
@@ -12,12 +12,10 @@ impl Formatter for PrevLineBreakRemover {
             .flatten();
 
         if let Some(line_break_pos) = line_break_pos {
-            let remove_start_pos = line_break_pos + 1;
-            content.replace_range(remove_start_pos..byte_pos, "");
-            return remove_start_pos;
+            (line_break_pos + 1, byte_pos)
+        } else {
+            (byte_pos, byte_pos)
         }
-
-        byte_pos
     }
 }
 
@@ -29,73 +27,62 @@ mod tests {
     fn test_format() {
         let remover = PrevLineBreakRemover {};
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |             ^
-        let mut content = "    hoge++    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 14), 9);
-        assert_eq!(content, "    hoge++    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             012345678901234567890123456
+        //             |             ^
+        let content = "    hoge++    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 14), (9, 14));
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |            ^
-        let mut content = "    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+    +    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             012345678901234567890123456
+        //             |            ^
+        let content = "    hoge+    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
-        //                          10        20
-        //                 012345678901234567890123456
-        //                 |            ^
-        let mut content = "    hoge+  x +    foo</div>".replace('+', "\n");
+        //                      10        20
+        //             012345678901234567890123456
+        //             |            ^
+        let content = "    hoge+  x +    foo</div>".replace('+', "\n");
         let remover = PrevLineBreakRemover {};
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge+  x +    foo</div>".replace('+', "\n"));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
-        //                          10        20
-        //                 0123456789012345678901234567
-        //                 |             ^
-        let mut content = "    hoge +    +    foo</div>".replace('+', "\n");
-        let remover = PrevLineBreakRemover {};
-        assert_eq!(remover.format(&mut content, 14), 14);
-        assert_eq!(content, "    hoge +    +    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             0123456789012345678901234567
+        //             |             ^
+        let content = "    hoge +    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 14), (14, 14));
 
-        //                          10        20
-        //                 0123456789012345678901234567
-        //                 |            ^
-        let mut content = "    hoge +    +    foo</div>".replace('+', "\n");
-        let remover = PrevLineBreakRemover {};
-        assert_eq!(remover.format(&mut content, 13), 13);
-        assert_eq!(content, "    hoge +    +    foo</div>".replace('+', "\n"));
+        //                      10        20
+        //             0123456789012345678901234567
+        //             |            ^
+        let content = "    hoge +    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
-        //                          10
-        //                 012345678901234567
-        //                 |      ^
-        let mut content = "+hoge++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 7), 6);
-        assert_eq!(content, "+hoge+++baz</div>".replace('+', "\n"));
+        //                      10
+        //             012345678901234567
+        //             |      ^
+        let content = "+hoge++++baz</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 7), (6, 7));
 
-        //                          10
-        //                 01234567890123
-        //                 |  ^
-        let mut content = "+++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 3), 2);
-        assert_eq!(content, "++++baz</div>".replace('+', "\n"));
+        //                      10
+        //             01234567890123
+        //             |  ^
+        let content = "+++++baz</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 3), (2, 3));
 
-        //                          10
-        //                 01234567890123
-        //                 |  ^
-        let mut content = "aaaabaz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 3), 3);
-        assert_eq!(content, "aaaabaz</div>".replace('+', "\n"));
+        //                      10
+        //             01234567890123
+        //             |  ^
+        let content = "aaaabaz</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 3), (3, 3));
 
-        //                          10
-        //                 012345.890123
-        //                 |     ^
-        let mut content = "aaa+ あ</div>".replace('+', "\n");
-        assert_eq!(remover.format(&mut content, 7), 7);
-        assert_eq!(content, "aaa+ あ</div>".replace('+', "\n"));
+        //                     10
+        //             012345.890123
+        //             |     ^
+        let content = "aaa+ あ</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 7), (7, 7));
 
-        let mut content = "\n".to_string();
-        assert_eq!(remover.format(&mut content, 0), 0);
+        let content = "\n".to_string();
+        assert_eq!(remover.format(&content, 0), (0, 0));
     }
 }

--- a/src/formatter/prev_line_break_remover.rs
+++ b/src/formatter/prev_line_break_remover.rs
@@ -4,7 +4,7 @@ use super::Formatter;
 pub struct PrevLineBreakRemover {}
 
 impl Formatter for PrevLineBreakRemover {
-    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_prev_line_break_pos(content, bytes, byte_pos)
@@ -12,10 +12,14 @@ impl Formatter for PrevLineBreakRemover {
             .flatten();
 
         if let Some(line_break_pos) = line_break_pos {
-            (line_break_pos + 1, byte_pos)
-        } else {
-            (byte_pos, byte_pos)
+            if line_break_pos <= next_byte_pos {
+                return (byte_pos, byte_pos);
+            }
+
+            return (line_break_pos + 1, byte_pos);
         }
+
+        (byte_pos, byte_pos)
     }
 }
 
@@ -31,58 +35,64 @@ mod tests {
         //             012345678901234567890123456
         //             |             ^
         let content = "    hoge++    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 14), (9, 14));
+        assert_eq!(remover.format(&content, 14, 0), (9, 14));
+
+        //                      10        20
+        //             012345678901234567890123456
+        //       (remove marker)^    ^
+        let content = "    hoge++    +    foo</div>".replace('+', "\n");
+        assert_eq!(remover.format(&content, 14, 9), (14, 14));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 13));
+        assert_eq!(remover.format(&content, 13, 0), (13, 13));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+  x +    foo</div>".replace('+', "\n");
         let remover = PrevLineBreakRemover {};
-        assert_eq!(remover.format(&content, 13), (13, 13));
+        assert_eq!(remover.format(&content, 13, 0), (13, 13));
 
         //                      10        20
         //             0123456789012345678901234567
         //             |             ^
         let content = "    hoge +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 14), (14, 14));
+        assert_eq!(remover.format(&content, 14, 0), (14, 14));
 
         //                      10        20
         //             0123456789012345678901234567
         //             |            ^
         let content = "    hoge +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13), (13, 13));
+        assert_eq!(remover.format(&content, 13, 0), (13, 13));
 
         //                      10
         //             012345678901234567
         //             |      ^
         let content = "+hoge++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7), (6, 7));
+        assert_eq!(remover.format(&content, 7, 0), (6, 7));
 
         //                      10
         //             01234567890123
         //             |  ^
         let content = "+++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 3), (2, 3));
+        assert_eq!(remover.format(&content, 3, 0), (2, 3));
 
         //                      10
         //             01234567890123
         //             |  ^
         let content = "aaaabaz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 3), (3, 3));
+        assert_eq!(remover.format(&content, 3, 0), (3, 3));
 
         //                     10
         //             012345.890123
         //             |     ^
         let content = "aaa+ あ</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7), (7, 7));
+        assert_eq!(remover.format(&content, 7, 0), (7, 7));
 
         let content = "\n".to_string();
-        assert_eq!(remover.format(&content, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0, 0), (0, 0));
     }
 }


### PR DESCRIPTION
現在のフォーマッタは次の削除マーカ(期間限定コンテンツを削除したカーソル)を越えて処理します。フォーマッタの挙動がその他の削除マーカに影響されないように、次の削除マーカを越えてフォーマットされないようにする必要があります。

また、フォーマット時には既に期間限定コンテンツの削除は終了しているので、次の削除マーカの位置を考慮してフォーマット処理を続行できるように、フォーマッタのインタフェースを調整します。

現在は、フォーマッタは指定範囲の文字の削除のみを行います。フォーマッタは削除位置を範囲で返却するようにしました。(将来的に削除以外のフォーマット処理をする場合は、この設計を再検討する必要があります)