### PR TITLE
Fix formatter empty line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +116,7 @@ dependencies = [
  "atty",
  "chrono",
  "clap",
+ "rstest",
 ]
 
 [[package]]
@@ -176,6 +186,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +337,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,21 +389,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.79"
+name = "pin-project-lite"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -275,9 +524,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -285,10 +534,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.12"
+name = "toml_datetime"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "utf8parse"
@@ -453,3 +719,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2021"
 chrono = "0.4.34"
 clap = { version = "4.5.1", features = ["derive"] }
 atty = "0.2"
+
+[dev-dependencies]
+rstest = "0.23.0"

--- a/src/chiritori.rs
+++ b/src/chiritori.rs
@@ -205,7 +205,6 @@ console.log("Released!")
 console.log("Temporary code until 9999/01/01")
 /* </time-limited> */
 
-
 /* <marker name="feature2"> */
 console.log("Temporary code while feature2 is not released")
 /* </marker> */

--- a/src/code/formatter.rs
+++ b/src/code/formatter.rs
@@ -8,7 +8,7 @@ pub mod next_line_break_remover;
 pub mod prev_line_break_remover;
 
 pub trait Formatter {
-    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize);
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize);
 }
 
 pub trait BlockFormatter {
@@ -68,7 +68,7 @@ fn format_block(
     formatters: &[Box<dyn Formatter>],
 ) -> Range<usize> {
     formatters.iter().fold(pos..pos, |range, f| {
-        let (start, end) = f.format(content, pos, prev_pos);
+        let (start, end) = f.format(content, pos);
         let start = std::cmp::max(start.min(range.start), prev_pos);
         let end = std::cmp::max(end.max(range.end), pos);
 

--- a/src/code/formatter.rs
+++ b/src/code/formatter.rs
@@ -30,9 +30,8 @@ pub fn format(
     let mut open_structure_remove_range: Vec<Range<usize>> = vec![];
 
     let removed_pos_iter = removed_pos.iter();
-    let mut prev_pos = 0;
     for (pos, pair_idx) in removed_pos_iter {
-        let range = format_block(content, *pos, prev_pos, formatters);
+        let range = format_block(content, *pos, formatters);
         ranges.push(range);
 
         if let Some(pair_idx) = pair_idx {
@@ -45,7 +44,6 @@ pub fn format(
                 open_structure_remove_range.extend(ranges);
             }
         }
-        prev_pos = *pos;
     }
 
     merge_ranges(&mut ranges, open_structure_remove_range);
@@ -64,13 +62,12 @@ pub fn format(
 fn format_block(
     content: &str,
     pos: usize,
-    prev_pos: usize,
     formatters: &[Box<dyn Formatter>],
 ) -> Range<usize> {
     formatters.iter().fold(pos..pos, |range, f| {
         let (start, end) = f.format(content, pos);
-        let start = std::cmp::max(start.min(range.start), prev_pos);
-        let end = std::cmp::max(end.max(range.end), pos);
+        let start = start.min(range.start);
+        let end = end.max(range.end);
 
         start..end
     })

--- a/src/code/formatter.rs
+++ b/src/code/formatter.rs
@@ -230,8 +230,22 @@ mod tests {
             "    hoge++    foo+".replace('+', "\n")
         );
 
-        // RemovePos 31 is unprossed because it conflicts with RemovePos 26
-        //
+        //                       10        20       30        40
+        //             0123456789012345678901234567890123456789012
+        //                                       ^    ^
+        let content = "+<div>+    +    +    +    +    +</div>".replace('+', "\n");
+        let removed_pos = [(27, None), (32, None)];
+        assert_eq!(
+            format(
+                &content,
+                &removed_pos,
+                &[Box::new(prev_line_break_remover::PrevLineBreakRemover {}),],
+                &[]
+            ),
+            //123456789012345678901234567890123456789012345
+            "+<div>+    +    +    +</div>".replace('+', "\n")
+        );
+
         //                       10        20       30        40
         //             0123456789012345678901234567890123456789012
         //                                       ^    ^
@@ -245,8 +259,9 @@ mod tests {
                 &[]
             ),
             //123456789012345678901234567890123456789012345
-            "+<div>+    +    ++    +</div>".replace('+', "\n")
+            "+<div>+    +    ++</div>".replace('+', "\n")
         );
+
 
         //                       10        20
         //             012345678901234567890123

--- a/src/code/formatter.rs
+++ b/src/code/formatter.rs
@@ -8,7 +8,7 @@ pub mod next_line_break_remover;
 pub mod prev_line_break_remover;
 
 pub trait Formatter {
-    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize);
+    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize);
 }
 
 pub trait BlockFormatter {

--- a/src/code/formatter/block_indent_remover.rs
+++ b/src/code/formatter/block_indent_remover.rs
@@ -47,7 +47,12 @@ impl BlockFormatter for BlockIndentRemover {
             None => 0,
         };
         let mut current_pos = start_byte_pos + 1;
-        let indent_len = get_indent_len(content, current_pos) - indent_ofs;
+        let first_indent_len = get_indent_len(content, current_pos);
+        let indent_len = if first_indent_len > indent_ofs {
+            first_indent_len - indent_ofs
+        } else {
+            0
+        };
 
         let mut positions = vec![];
         while end_byte_pos > current_pos {
@@ -131,6 +136,28 @@ mod tests {
         //             |   ^<>      <>     ^
         let content = "foo++  fuga++  piyo++bar".replace('+', "\n");
         assert_eq!(remover.format(&content, 4, 20), vec![5..7, 13..15]);
+
+        // If the indentation of the marker is greater than the indentation of the block, it cannot be removed.
+        //
+        //   original       removed       formatted
+        // +---------+    +---------+    +---------+
+        // | foo+    |    | foo+    |    | foo+    |
+        // | ...<rm>+|    | ...+    |    | ...+    |
+        // | if {+   |    | ..fuga+ |    | ..fuga+ |
+        // | ..fuga+ | => | +       |    | +       |
+        // | +       |    | ..piyo+ | => | piyo+   |
+        // | ..piyo+ |    | +       |    | +       |
+        // | }+      |    | bar     |    | bar     |
+        // | </rm>+  |    |         |    |         |
+        // | bar+    |    |         |    |         |
+        // +---------+    +---------+    +---------+
+        //
+        //                      10        20
+        //             012345678901234567890123456
+        //             |      ^               ^
+        let content = "foo+   +  fuga++  piyo++bar".replace('+', "\n");
+        assert_eq!(remover.format(&content, 7, 20), vec![]);
+
 
         //    original          removed          formatted
         // +------------+    +------------+    +------------+

--- a/src/code/formatter/block_indent_remover.rs
+++ b/src/code/formatter/block_indent_remover.rs
@@ -8,6 +8,32 @@ use std::ops::Range;
 pub struct BlockIndentRemover {}
 
 impl BlockFormatter for BlockIndentRemover {
+    /// Return ranges of indents to be removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// //         input                output            removed
+    /// //  +----------------+    +----------------+    +---------+
+    /// //  |  f o o +       |    |  f o o +       |    | foo+    |
+    /// //  | [+             |    |  +             |    | +       |
+    /// //  |  . . f u g a + |    | [. .]f u g a + |    | fuga+   |
+    /// //  |  . . p i y o + | => | [. .]p i y o + | => | piyo+   |
+    /// //  |  +]            |    |  +             |    | +       |
+    /// //  |  b a r         |    |  b a r         |    | bar     |
+    /// //  +----------------+    +----------------+    +---------+
+    /// //
+    /// //                      10        20
+    /// //         pos 01234567890123456789012
+    /// //             |   |~~     ~~     |
+    /// //             |   |^      ^      |
+    /// //             |   |removal ranges|
+    /// //             |   |              |
+    /// //             |   | block range  |
+    /// //             |   |<------------>|
+    /// let content = "foo++  fuga+  piyo++bar".replace('+', "\n");
+    /// assert_eq!(remover.format(&content, 4, 19), vec![5..7, 12..14]);
+    /// ```
     fn format(
         &self,
         content: &str,

--- a/src/code/formatter/empty_line_remover.rs
+++ b/src/code/formatter/empty_line_remover.rs
@@ -42,7 +42,7 @@ impl Formatter for EmptyLineRemover {
     /// let content = "    hoge+++  foo".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 9, 0), (9, 9));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         if !content.is_char_boundary(byte_pos) {
@@ -58,7 +58,7 @@ impl Formatter for EmptyLineRemover {
             .is_none();
         let is_not_prev_line_empty = find_prev_line_break_pos(content, bytes, byte_pos, true)
             .and_then(|pos| find_prev_line_break_pos(content, bytes, pos, true))
-            .map_or(true, |pos| pos <= prev_byte_pos);
+            .is_none();
 
         if is_not_next_line_empty && is_not_prev_line_empty {
             (byte_pos, byte_pos + 1)
@@ -81,13 +81,6 @@ mod tests {
         //             |        ^
         let content = "    hoge++  foo".replace('+', "\n");
         assert_eq!(remover.format(&content, 9, 0), (9, 10));
-
-        //                      10
-        //             0123456789012345
-        //       (remove marker)^|
-        //             |         ^
-        let content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10, 9), (10, 11));
 
         //                      10
         //             0123456789012345

--- a/src/code/formatter/empty_line_remover.rs
+++ b/src/code/formatter/empty_line_remover.rs
@@ -42,7 +42,7 @@ impl Formatter for EmptyLineRemover {
     /// let content = "    hoge+++  foo".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 9, 0), (9, 9));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         if !content.is_char_boundary(byte_pos) {
@@ -80,24 +80,24 @@ mod tests {
         //             0123456789012345
         //             |        ^
         let content = "    hoge++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 9, 0), (9, 10));
+        assert_eq!(remover.format(&content, 9), (9, 10));
 
         //                      10
         //             0123456789012345
         //             |         ^
         let content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10, 0), (10, 10));
+        assert_eq!(remover.format(&content, 10), (10, 10));
 
         //                      10
         //             0123456789012345
         //             |        ^
         let content = "    hoge+++  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 9, 0), (9, 9));
+        assert_eq!(remover.format(&content, 9), (9, 9));
 
         //                      10
         //             01234567890123456
         //             |         ^
         let content = "    hoge++ +  foo".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10, 0), (10, 10));
+        assert_eq!(remover.format(&content, 10), (10, 10));
     }
 }

--- a/src/code/formatter/empty_line_remover.rs
+++ b/src/code/formatter/empty_line_remover.rs
@@ -7,6 +7,41 @@ use super::Formatter;
 pub struct EmptyLineRemover {}
 
 impl Formatter for EmptyLineRemover {
+    /// Return the range of blank spaces to be deleted.
+    ///
+    /// If the line immediately after the deletion position is a new line and there are no blank lines before or after it,
+    /// the new line immediately after the deletion position is deleted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// //           input                      output               removed
+    /// //  +---------------------+    +---------------------+    +-----------+
+    /// //  |  . . . . h o g e +  |    |  . . . . h o g e +  |    | ....hoge+ |
+    /// //  | [+                  | => | [+]                 | => | ..foo+    |
+    /// //  |  . . f o o +        |    |  . . f o o +        |    |           |
+    /// //  +---------------------+    +---------------------+    +-----------+
+    /// //
+    /// //                      10        20
+    /// //         pos 012345678901234
+    /// //             |        -
+    /// //             |        Removal line break
+    /// let content = "    hoge++  foo".replace('+', "\n");
+    /// assert_eq!(remover.format(&content, 9, 0), (9, 10));
+    ///
+    /// //           input           removed (No changed)
+    /// //  +---------------------+    +-----------+
+    /// //  |  . . . . h o g e +  |    | ....hoge+ |
+    /// //  | [+                  | => | +         |
+    /// //  |  +                  |    | +         |
+    /// //  |  . . f o o +        |    | ..foo+    |
+    /// //  +---------------------+    +-----------+
+    /// //
+    /// //                      10        20
+    /// //         pos 01234567890123456789012
+    /// let content = "    hoge+++  foo".replace('+', "\n");
+    /// assert_eq!(remover.format(&content, 9, 0), (9, 9));
+    /// ```
     fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 

--- a/src/code/formatter/empty_line_remover.rs
+++ b/src/code/formatter/empty_line_remover.rs
@@ -42,7 +42,7 @@ impl Formatter for EmptyLineRemover {
     /// let content = "    hoge+++  foo".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 9, 0), (9, 9));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         if !content.is_char_boundary(byte_pos) {
@@ -58,7 +58,7 @@ impl Formatter for EmptyLineRemover {
             .is_none();
         let is_not_prev_line_empty = find_prev_line_break_pos(content, bytes, byte_pos, true)
             .and_then(|pos| find_prev_line_break_pos(content, bytes, pos, true))
-            .map_or(true, |pos| pos <= next_byte_pos);
+            .map_or(true, |pos| pos <= prev_byte_pos);
 
         if is_not_next_line_empty && is_not_prev_line_empty {
             (byte_pos, byte_pos + 1)

--- a/src/code/formatter/indent_remover.rs
+++ b/src/code/formatter/indent_remover.rs
@@ -22,7 +22,7 @@ impl Formatter for IndentRemover {
     /// let content = "foo+    +    +    bar".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 8, 0), (4, 8));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize) {
         let mut cursor = byte_pos;
         let bytes = content.as_bytes();
 
@@ -37,7 +37,7 @@ impl Formatter for IndentRemover {
 
             cursor -= 1;
 
-            if cursor <= next_byte_pos {
+            if cursor <= prev_byte_pos {
                 break false;
             }
 

--- a/src/code/formatter/indent_remover.rs
+++ b/src/code/formatter/indent_remover.rs
@@ -2,6 +2,26 @@ use super::Formatter;
 pub struct IndentRemover {}
 
 impl Formatter for IndentRemover {
+    /// Return the range of blank spaces ( = an indent ) to be deleted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// //           input                      output               removed
+    /// //  +---------------------+    +---------------------+    +-----------+
+    /// //  |  f o o +            |    |  f o o +            |    | foo+      |
+    /// //  |  . . . .]+          | => | [. . . .]+          | => | +         |
+    /// //  |  . . . . +          |    |  . . . . +          |    | ....+     |
+    /// //  |  . . . . b a r      |    |  . . . . b a r      |    | ....bar   |
+    /// //  +---------------------+    +---------------------+    +-----------+
+    /// //
+    /// //                      10        20
+    /// //         pos 01234567890123456789012
+    /// //             |   ----
+    /// //             |   Removal spaces
+    /// let content = "foo+    +    +    bar".replace('+', "\n");
+    /// assert_eq!(remover.format(&content, 8, 0), (4, 8));
+    /// ```
     fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
         let mut cursor = byte_pos;
         let bytes = content.as_bytes();

--- a/src/code/formatter/indent_remover.rs
+++ b/src/code/formatter/indent_remover.rs
@@ -22,7 +22,7 @@ impl Formatter for IndentRemover {
     /// let content = "foo+    +    +    bar".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 8, 0), (4, 8));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
         let mut cursor = byte_pos;
         let bytes = content.as_bytes();
 
@@ -36,10 +36,6 @@ impl Formatter for IndentRemover {
             }
 
             cursor -= 1;
-
-            if cursor <= prev_byte_pos {
-                break false;
-            }
 
             let current = bytes.get(cursor);
 
@@ -80,12 +76,6 @@ mod tests {
         //             |               ^   ^
         let content = "+<div>+    hoge+    +    foo</div>".replace('+', "\n");
         assert_eq!(remover.format(&content, 20, 0), (16, 20));
-
-        //                      10        20        30
-        //             0123456789012345678901234567890123
-        //             |  (remove marker)^ ^
-        let content = "+<div>+    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 20, 18), (20, 20));
 
         // if next char is '\n', and previous char is not space, do nothing
         //

--- a/src/code/formatter/indent_remover.rs
+++ b/src/code/formatter/indent_remover.rs
@@ -22,7 +22,7 @@ impl Formatter for IndentRemover {
     /// let content = "foo+    +    +    bar".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 8, 0), (4, 8));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let mut cursor = byte_pos;
         let bytes = content.as_bytes();
 
@@ -75,7 +75,7 @@ mod tests {
         //             0123456789012345678901234567890123
         //             |               ^   ^
         let content = "+<div>+    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 20, 0), (16, 20));
+        assert_eq!(remover.format(&content, 20), (16, 20));
 
         // if next char is '\n', and previous char is not space, do nothing
         //
@@ -83,7 +83,7 @@ mod tests {
         //             0123456789012345678901234567890123
         //             |            ^
         let content = "+<div>+hoge++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 13));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
         // if next char is not '\n', do nothing
         //
@@ -91,7 +91,7 @@ mod tests {
         //             012345678901
         //             |      ^
         let content = "hoge+  a+baz".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7, 0), (7, 7));
+        assert_eq!(remover.format(&content, 7), (7, 7));
 
         // if next char is not '\n', do nothing
         //
@@ -99,7 +99,7 @@ mod tests {
         //             012345678901
         //             | ^
         let content = "  +baz".replace('+', "\n");
-        assert_eq!(remover.format(&content, 2, 0), (2, 2));
+        assert_eq!(remover.format(&content, 2), (2, 2));
 
         // if char boundary is invalid, do nothing
         //
@@ -107,12 +107,12 @@ mod tests {
         //             0123456789.2345678901234567890123
         //             |         ^
         let content = "+<div>+  あ  +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 10, 0), (10, 10));
+        assert_eq!(remover.format(&content, 10), (10, 10));
 
         let content = "".to_string();
-        assert_eq!(remover.format(&content, 0, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0), (0, 0));
 
         let content = "\n".to_string();
-        assert_eq!(remover.format(&content, 0, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0), (0, 0));
     }
 }

--- a/src/code/formatter/next_line_break_remover.rs
+++ b/src/code/formatter/next_line_break_remover.rs
@@ -4,6 +4,29 @@ use super::Formatter;
 pub struct NextLineBreakRemover {}
 
 impl Formatter for NextLineBreakRemover {
+    /// Return the range of a blank line to be removed.
+    ///
+    /// If there are two consecutive blank lines from the removal position,
+    /// the immediately following blank line is removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// //           input                     output             removed
+    /// //  +--------------------+    +--------------------+    +---------+
+    /// //  |  f o o +           |    |  f o o +           |    | foo+    |
+    /// //  |  . . .[. +         | => |  . . .[. +         | => | ...+    |
+    /// //  |  . . +             |    |  . .]+             |    | ....bar |
+    /// //  |  . . . .  b a r    |    |  . . . .  b a r    |    |         |
+    /// //  +--------------------+    +--------------------+    +---------+
+    /// //
+    /// //                      10
+    /// //         pos 0123456789012345678
+    /// //             |     -----
+    /// //             |     Removal an empty line
+    /// let content = "foo+    +  +    bar".replace('+', "\n");
+    /// assert_eq!(remover.format(&content, 7, 0), (7, 11));
+    /// ```
     fn format(&self, content: &str, byte_pos: usize, _next_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 

--- a/src/code/formatter/next_line_break_remover.rs
+++ b/src/code/formatter/next_line_break_remover.rs
@@ -27,7 +27,7 @@ impl Formatter for NextLineBreakRemover {
     /// let content = "foo+    +  +    bar".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 7, 0), (7, 11));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, _next_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_next_line_break_pos(content, bytes, byte_pos, true)

--- a/src/code/formatter/next_line_break_remover.rs
+++ b/src/code/formatter/next_line_break_remover.rs
@@ -27,7 +27,7 @@ impl Formatter for NextLineBreakRemover {
     /// let content = "foo+    +  +    bar".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 7, 0), (7, 11));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_next_line_break_pos(content, bytes, byte_pos, true)
@@ -53,48 +53,48 @@ mod tests {
         //             012345678901234567890123456
         //             |            ^  ^
         let content = "    hoge+    +  +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 16));
+        assert_eq!(remover.format(&content, 13), (13, 16));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+      +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 20));
+        assert_eq!(remover.format(&content, 13), (13, 20));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 13));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
         //                      10
         //             01234567890123456
         //             |            ^
         let content = "    hoge+    +  ".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 13));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+    ++++    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 14));
+        assert_eq!(remover.format(&content, 13), (13, 14));
 
         //                      10
         //             01234567890123
         //             |  ^
         let content = "aaaabaz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 3, 0), (3, 3));
+        assert_eq!(remover.format(&content, 3), (3, 3));
 
         //                     10
         //             012345.890123
         //             |     ^
         let content = "aaa+ あ</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7, 0), (7, 7));
+        assert_eq!(remover.format(&content, 7), (7, 7));
 
         let content = "".to_string();
-        assert_eq!(remover.format(&content, 0, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0), (0, 0));
 
         let content = "\n".to_string();
-        assert_eq!(remover.format(&content, 0, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0), (0, 0));
     }
 }

--- a/src/code/formatter/prev_line_break_remover.rs
+++ b/src/code/formatter/prev_line_break_remover.rs
@@ -5,6 +5,29 @@ use super::Formatter;
 pub struct PrevLineBreakRemover {}
 
 impl Formatter for PrevLineBreakRemover {
+    /// Return the range of a blank line to be removed.
+    ///
+    /// If two consecutive blank lines start at the removal position,
+    /// the preceding blank line is removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// //           input               output           removed
+    /// //  +----------------+    +----------------+    +---------+
+    /// //  |  . . h o g e + |    |  . . h o g e + |    | ..hoge+ |
+    /// //  |  . +           | => | [. +           | => | .+      |
+    /// //  |  . . .]. +     |    |  . . .]. +     |    | ....foo |
+    /// //  |  . . . . f o o |    |  . . . . f o o |    |         |
+    /// //  +----------------+    +----------------+    +---------+
+    /// //
+    /// //                      10
+    /// //         pos 01234567890123456789
+    /// //             |      ------
+    /// //             |      Removal an empty line
+    /// let content = "  hoge+ +    +    foo".replace('+', "\n");
+    /// assert_eq!(remover.format(&content, 12, 0), (7, 12));
+    /// ```
     fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 

--- a/src/code/formatter/prev_line_break_remover.rs
+++ b/src/code/formatter/prev_line_break_remover.rs
@@ -28,14 +28,14 @@ impl Formatter for PrevLineBreakRemover {
     /// let content = "  hoge+ +    +    foo".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 12, 0), (7, 12));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, next_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_prev_line_break_pos(content, bytes, byte_pos, true)
             .and_then(|pos| find_prev_line_break_pos(content, bytes, pos, true));
 
         if let Some(line_break_pos) = line_break_pos {
-            if line_break_pos <= next_byte_pos {
+            if line_break_pos <= prev_byte_pos {
                 return (byte_pos, byte_pos);
             }
 

--- a/src/code/formatter/prev_line_break_remover.rs
+++ b/src/code/formatter/prev_line_break_remover.rs
@@ -28,17 +28,13 @@ impl Formatter for PrevLineBreakRemover {
     /// let content = "  hoge+ +    +    foo".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 12, 0), (7, 12));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_prev_line_break_pos(content, bytes, byte_pos, true)
             .and_then(|pos| find_prev_line_break_pos(content, bytes, pos, true));
 
         if let Some(line_break_pos) = line_break_pos {
-            if line_break_pos <= prev_byte_pos {
-                return (byte_pos, byte_pos);
-            }
-
             return (line_break_pos + 1, byte_pos);
         }
 
@@ -59,12 +55,6 @@ mod tests {
         //             |             ^
         let content = "    hoge++    +    foo</div>".replace('+', "\n");
         assert_eq!(remover.format(&content, 14, 0), (9, 14));
-
-        //                      10        20
-        //             012345678901234567890123456
-        //       (remove marker)^    ^
-        let content = "    hoge++    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 14, 9), (14, 14));
 
         //                      10        20
         //             012345678901234567890123456

--- a/src/code/formatter/prev_line_break_remover.rs
+++ b/src/code/formatter/prev_line_break_remover.rs
@@ -28,7 +28,7 @@ impl Formatter for PrevLineBreakRemover {
     /// let content = "  hoge+ +    +    foo".replace('+', "\n");
     /// assert_eq!(remover.format(&content, 12, 0), (7, 12));
     /// ```
-    fn format(&self, content: &str, byte_pos: usize, _prev_byte_pos: usize) -> (usize, usize) {
+    fn format(&self, content: &str, byte_pos: usize) -> (usize, usize) {
         let bytes = content.as_bytes();
 
         let line_break_pos = find_prev_line_break_pos(content, bytes, byte_pos, true)
@@ -54,58 +54,58 @@ mod tests {
         //             012345678901234567890123456
         //             |             ^
         let content = "    hoge++    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 14, 0), (9, 14));
+        assert_eq!(remover.format(&content, 14), (9, 14));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 13));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
         //                      10        20
         //             012345678901234567890123456
         //             |            ^
         let content = "    hoge+  x +    foo</div>".replace('+', "\n");
         let remover = PrevLineBreakRemover {};
-        assert_eq!(remover.format(&content, 13, 0), (13, 13));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
         //                      10        20
         //             0123456789012345678901234567
         //             |             ^
         let content = "    hoge +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 14, 0), (14, 14));
+        assert_eq!(remover.format(&content, 14), (14, 14));
 
         //                      10        20
         //             0123456789012345678901234567
         //             |            ^
         let content = "    hoge +    +    foo</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 13, 0), (13, 13));
+        assert_eq!(remover.format(&content, 13), (13, 13));
 
         //                      10
         //             012345678901234567
         //             |      ^
         let content = "+hoge++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7, 0), (6, 7));
+        assert_eq!(remover.format(&content, 7), (6, 7));
 
         //                      10
         //             01234567890123
         //             |  ^
         let content = "+++++baz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 3, 0), (2, 3));
+        assert_eq!(remover.format(&content, 3), (2, 3));
 
         //                      10
         //             01234567890123
         //             |  ^
         let content = "aaaabaz</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 3, 0), (3, 3));
+        assert_eq!(remover.format(&content, 3), (3, 3));
 
         //                     10
         //             012345.890123
         //             |     ^
         let content = "aaa+ あ</div>".replace('+', "\n");
-        assert_eq!(remover.format(&content, 7, 0), (7, 7));
+        assert_eq!(remover.format(&content, 7), (7, 7));
 
         let content = "\n".to_string();
-        assert_eq!(remover.format(&content, 0, 0), (0, 0));
+        assert_eq!(remover.format(&content, 0), (0, 0));
     }
 }

--- a/src/integration-test-fixtures/test001.input.js
+++ b/src/integration-test-fixtures/test001.input.js
@@ -1,0 +1,15 @@
+function main() {
+  console.log('Hello, World! 1');
+  /* < time-limited to="2020-12-31 23:59:59" > */
+    console.log('🧹This code will be removed after 2020-12-31T23:59:59.999Z');
+  /* < /time-limited > */
+
+  /* < time-limited to="2099-12-31 23:59:59" > */
+    console.log('📌This code will be removed after 2099-12-31T23:59:59.999Z');
+  /* < /time-limited > */
+
+  /* < time-limited to="2020-12-31 23:59:59" > */
+    console.log('🧹This code will be removed after 2020-12-31T23:59:59.999Z');
+  /* < /time-limited > */
+  console.log('Hello, World! 2');
+}

--- a/src/integration-test-fixtures/test001.input.js
+++ b/src/integration-test-fixtures/test001.input.js
@@ -1,4 +1,4 @@
-function main() {
+async function main() {
   console.log('Hello, World! 1');
   /* < time-limited to="2020-12-31 23:59:59" > */
     console.log('🧹This code will be removed after 2020-12-31T23:59:59.999Z');
@@ -11,5 +11,38 @@ function main() {
   /* < time-limited to="2020-12-31 23:59:59" > */
     console.log('🧹This code will be removed after 2020-12-31T23:59:59.999Z');
   /* < /time-limited > */
+
+  const isReleased = await fetch('https://example.test/features/awesome-feature')
+
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  if (isReleased) {
+    console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+    const awesomeFeature = new awesomeFeature()
+    awesomeFeature.run();
+  }
+  /* < /time-limited > */
+
+  for (let i = 0; i < 10; i++) {
+    /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+    if (isReleased) {
+      console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+      awesomeFeature.add(i);
+    }
+    /* < /time-limited > */
+  }
+
+/* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  if (isReleased) {
+    console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+  }
+/* < /time-limited > */
+
+  /* If the indentation of the marker is greater than the indentation of the block, it cannot be removed. */
+        /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  if (isReleased) {
+    console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+  }
+        /* < /time-limited > */
+
   console.log('Hello, World! 2');
 }

--- a/src/integration-test-fixtures/test001.input.js.expected
+++ b/src/integration-test-fixtures/test001.input.js.expected
@@ -1,0 +1,9 @@
+function main() {
+  console.log('Hello, World! 1');
+
+  /* < time-limited to="2099-12-31 23:59:59" > */
+    console.log('📌This code will be removed after 2099-12-31T23:59:59.999Z');
+  /* < /time-limited > */
+
+  console.log('Hello, World! 2');
+}

--- a/src/integration-test-fixtures/test001.input.js.expected
+++ b/src/integration-test-fixtures/test001.input.js.expected
@@ -1,9 +1,25 @@
-function main() {
+async function main() {
   console.log('Hello, World! 1');
 
   /* < time-limited to="2099-12-31 23:59:59" > */
     console.log('📌This code will be removed after 2099-12-31T23:59:59.999Z');
   /* < /time-limited > */
+
+  const isReleased = await fetch('https://example.test/features/awesome-feature')
+
+  console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+  const awesomeFeature = new awesomeFeature()
+  awesomeFeature.run();
+
+  for (let i = 0; i < 10; i++) {
+    console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+    awesomeFeature.add(i);
+  }
+
+console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
+
+  /* If the indentation of the marker is greater than the indentation of the block, it cannot be removed. */
+    console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
 
   console.log('Hello, World! 2');
 }


### PR DESCRIPTION
Formatterでフォーマットする際、これまでは処理対象のソースコードの削除とフォーマット処理を同時に行っていたため、処理の競合によって処理前の削除マーカーの位置が変化しないよう、Formatterが出力する範囲から処理してはいけない範囲を除外する処理をしていました。

https://github.com/piyoppi/chiritori/pull/10 において、Formatterの削除範囲決定処理をすべて終えてから範囲をマージし、ソースコードを範囲に従って削除するように変更しました。これにより、Formatterの削除範囲の決定においてソースコードに対する副作用がなくなったため、前述したような範囲の除外処理が不要になりました。

この不要な処理を削除して整理することで、複数の削除マーカーが存在するときに発生する削除漏れが発生しないようにします。