### PR TITLE
Rename <marker> default name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,10 +41,11 @@ struct Args {
     #[arg(long, default_value = "")]
     time_limited_current: String,
 
-    /// The tag name for marker
-    #[arg(long, default_value = "marker")]
+    /// The tag name for removal-marker
+    #[arg(long, default_value = "removal-marker")]
     marker_tag_name: String,
 
+    /// Name of removal-marker to be removed
     #[arg(long, default_value = "vec![]")]
     marker_removal_names: Vec<String>,
 }


### PR DESCRIPTION
ユースケースとして以下のようなものを想定しています。

- デリミタを `<` `>` に設定し、HTML上のカスタム要素と連動して表示・非表示を制御する
- あとからChiritoriで除去する

このとき、カスタム要素の要件として名前にハイフンが入っていることが要求されます。

https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts

この要件と、デフォルト値としての「marker」というタグ名がマッチしないので、デフォルト値もハイフンを入れておき「removal-marker」とします。