### PR TITLE
Rename default delimiters

### DIFF
--- a/samples/sample-code.html
+++ b/samples/sample-code.html
@@ -7,21 +7,21 @@
   <body>
     <h1>Hello World</h1>
     <p>This is a sample page with some code.</p>
-    <!-- time-limited to="2019-12-31 23:59:59" -->
+    <!-- <time-limited to="2019-12-31 23:59:59"> -->
       <p>This content is only available until the end of the year.</p>
       <p>After that, it will be removed from the page.</p>
-    <!-- /time-limited -->
-    <!-- time-limited to="2999-12-31 23:59:59" -->
+    <!-- </time-limited> -->
+    <!-- <time-limited to="2999-12-31 23:59:59"> -->
       Campaign!
-      <!-- time-limited to="2001-12-31 23:59:59" -->
+      <!-- <time-limited to="2001-12-31 23:59:59"> -->
         40% off! Only until the 2001/12/31!
-      <!-- /time-limited -->
-    <!-- /time-limited -->
-    <!-- time-limited to="2001-12-31 23:59:59" -->
-      <!-- time-limited to="2999-12-31 23:59:59" -->
+      <!-- </time-limited> -->
+    <!-- </time-limited> -->
+    <!-- <time-limited to="2001-12-31 23:59:59"> -->
+      <!-- <time-limited to="2999-12-31 23:59:59"> -->
         Campaign!
-      <!-- /time-limited -->
+      <!-- </time-limited> -->
       until the 2001/12/31!
-    <!-- /time-limited -->
+    <!-- </time-limited> -->
   </body>
 </html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,11 @@ struct Args {
     output: Option<String>,
 
     /// The delimiter start
-    #[arg(long, default_value = "<!--")]
+    #[arg(long, default_value = "<!-- <")]
     delimiter_start: String,
 
     /// The delimiter end
-    #[arg(long, default_value = "-->")]
+    #[arg(long, default_value = "> -->")]
     delimiter_end: String,
 
     /// The tag name for time-limited content


### PR DESCRIPTION
デフォルトのデリミタ `<!--` `-->` はHTMLのコメント構文そのままなので、関係ないものがタグとして認識されそうなので変更しておく。