### PR TITLE
unwrap-block strategy requires removal targets

### DIFF
--- a/src/code/remover.rs
+++ b/src/code/remover.rs
@@ -58,6 +58,11 @@ fn build_remove_marker(
                         true => create(el, remove_strategy_map),
                         false => None,
                     })
+                    .and_then(|(range, closed_range)| if !range.is_empty() {
+                        Some((range, closed_range))
+                    } else {
+                        None
+                    })
             };
 
             let child_markers =

--- a/src/integration-test-fixtures/test001.input.js
+++ b/src/integration-test-fixtures/test001.input.js
@@ -37,6 +37,13 @@ async function main() {
   }
 /* < /time-limited > */
 
+  /* unwrap-block requires a removal target immediately after the start tag and immediately before the end tag. */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  /* < /time-limited > */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  foo()
+  /* < /time-limited > */
+
   /* If the indentation of the marker is greater than the indentation of the block, it cannot be removed. */
         /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
   if (isReleased) {
@@ -44,5 +51,8 @@ async function main() {
   }
         /* < /time-limited > */
 
+  /* unwrap-block requires a line break immediately after the start tag and immediately before the end tag. */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */ foo() /* < /time-limited > */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > *//* < /time-limited > */
   console.log('Hello, World! 2');
 }

--- a/src/integration-test-fixtures/test001.input.js.expected
+++ b/src/integration-test-fixtures/test001.input.js.expected
@@ -18,8 +18,18 @@ async function main() {
 
 console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
 
+  /* unwrap-block requires a removal target immediately after the start tag and immediately before the end tag. */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  /* < /time-limited > */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */
+  foo()
+  /* < /time-limited > */
+
   /* If the indentation of the marker is greater than the indentation of the block, it cannot be removed. */
     console.log('📌This code is unconditionally executed after 2020-12-31T23:59:59.999Z');
 
+  /* unwrap-block requires a line break immediately after the start tag and immediately before the end tag. */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > */ foo() /* < /time-limited > */
+  /* < time-limited to="2020-12-31 23:59:59" unwrap-block > *//* < /time-limited > */
   console.log('Hello, World! 2');
 }


### PR DESCRIPTION
unwrap-blockは開始タグの直後の行と、終了タグの直前の行を消すことでブロックをアンラップします。これらの削除ターゲットが無い場合に実行時エラーになってしまうので対応します。