### PR TITLE
Fixes an error failing to parse if there is a newline after an attribute

### DIFF
--- a/src/element_parser.rs
+++ b/src/element_parser.rs
@@ -47,7 +47,7 @@ pub fn parse<'a>(token: &'a tokenizer::Token) -> Option<Element<'a>> {
                                 }
                             },
                             State::Name(start) => match current_char {
-                                ' ' => {
+                                ' ' | '\n' => {
                                     pairs.push((&target[start..pos], None));
                                     state = State::NameEnd;
                                 }
@@ -261,6 +261,18 @@ mod tests {
                         value: Some("456")
                     }
                 ],
+            })
+        );
+
+        let tokens = tokenizer::tokenize("<foo bar\n>", "<", ">");
+        assert_eq!(
+            parse(&tokens[0]),
+            Some(Element {
+                name: "foo",
+                attrs: vec![Attribute {
+                    name: "bar",
+                    value: None
+                }],
             })
         );
     }


### PR DESCRIPTION
属性名の直後に改行があるとパースに失敗する不具合を修正します。以下のように記述したとき、 `unwrap-block` が属性名としてパースされませんでした。

```html
/* <time-limited to="YYYY-MM-DD HH:MM:SS" unwrap-block
 *  c=""
 *  > */

/* </time-limited> */
```